### PR TITLE
Upgrade to Pydantic v2

### DIFF
--- a/codeinterpreterapi/config.py
+++ b/codeinterpreterapi/config.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from dotenv import load_dotenv
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 # .env file
 load_dotenv(dotenv_path="./.env")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ python = ">=3.9,<3.9.7 || >3.9.7,<4.0"
 python-dotenv = "^1"
 openai = "^0.27"
 pydantic = "^2"
+pydantic-settings = "^2"
 langchain = "^0.0.267"
 codeboxapi = ">=0.0.18"
 streamlit = { version = "^1", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ repository = "https://github.com/shroominic/codeinterpreter-api"
 python = ">=3.9,<3.9.7 || >3.9.7,<4.0"
 python-dotenv = "^1"
 openai = "^0.27"
-langchain = "^0.0.242"
+pydantic = "^2"
+langchain = "^0.0.267"
 codeboxapi = ">=0.0.18"
 streamlit = { version = "^1", optional = true }
 jupyter-kernel-gateway = { version = "^2", optional = true }


### PR DESCRIPTION
LangChain bumped to 267+ as that's when it officially started supporting Pydantic v2 (see [issue](https://github.com/langchain-ai/langchain/issues/6841#issuecomment-1682996914)). 

Note that this PR will only install correctly if my parallel PR for codeboxapi [here](https://github.com/shroominic/codebox-api/pull/10) is live, as otherwise there will be a conflict in required Pydantic versions. So if upgrading to Pydantic v2, the codeboxapi PR must be merged and published first, and the codeboxapi version requirement inside this package must be bumped accordingly.