### PR TITLE
Use ProactorEventLoop to run frontend app on Windows

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 
 import streamlit as st  # type: ignore
 
@@ -29,4 +30,9 @@ button_pressed = st.button("Run code interpreter", use_container_width=True)
 
 # This will display the images only when the button is pressed
 if button_pressed and input_text != "":
-    asyncio.run(get_images(input_text, files=uploaded_files_list))
+    if sys.platform == "win32":
+        loop = asyncio.ProactorEventLoop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(get_images(input_text, files=uploaded_files_list))
+    else:
+        asyncio.run(get_images(input_text, files=uploaded_files_list))


### PR DESCRIPTION
This pull request resolves #96 and resolves #61. The approach is to use ProactorEventLoop to run frontend app on Windows.