### PR TITLE
fix: frontend module not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Thanks!
 To start the web application created with streamlit:
 
 ```bash
-streamlit run frontend/app.py
+streamlit run frontend/app.py --browser.gatherUsageStats=False
 ```
 
 ## License

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -4,7 +4,7 @@ import sys
 import streamlit as st  # type: ignore
 
 from codeinterpreterapi import File
-from frontend.utils import get_images
+from utils import get_images
 
 # Page configuration
 st.set_page_config(layout="wide")


### PR DESCRIPTION
You can merge the [gitpod](https://github.com/bitsnaps/codeinterpreter-api/tree/gitpod) as well if you want, config file is ready.