### PR TITLE
Fixed newline SyntaxError

### DIFF
--- a/codeinterpreterapi/session.py
+++ b/codeinterpreterapi/session.py
@@ -109,6 +109,8 @@ class CodeInterpreterSession:
                 "Write the entire code in a single string. This string can "
                 "be really long, so you can use the `;` character to split lines. "
                 "Start your code on the same line as the opening quote. "
+                "Do not start your code with a line break. "
+                "For example, do 'import numpy', not '\\nimport numpy'."
                 "Variables are preserved between runs. "
                 + (
                     (

--- a/codeinterpreterapi/session.py
+++ b/codeinterpreterapi/session.py
@@ -108,6 +108,7 @@ class CodeInterpreterSession:
                 description="Input a string of code to a ipython interpreter. "
                 "Write the entire code in a single string. This string can "
                 "be really long, so you can use the `;` character to split lines. "
+                "Start your code on the same line as the opening quote. "
                 "Variables are preserved between runs. "
                 + (
                     (


### PR DESCRIPTION
Added some prompting to the python tool to resolve https://github.com/shroominic/codeinterpreter-api/issues/135 where multi-line code strings are not processed correctly if they're not formatted in compliance with Python's string literal rules. Specifically, the interpreter fails when the code string starts with a newline right after the opening quote or doesn't use triple quotes for multi-line code snippets. This leads to an unended string literal error because the interpreter expects a complete string format as per Python syntax rules.